### PR TITLE
QAI-10345: Updated sfnt-pingpong to use signed INT64 results

### DIFF
--- a/src/sfnettest.h
+++ b/src/sfnettest.h
@@ -298,6 +298,13 @@ extern void sfnt_iarray_mean_and_limits(const int* start, const int* end,
 extern void sfnt_iarray_variance(const int* start, const int* end,
                                int mean, int64_t* variance_out);
 
+extern int sfnt_qsort_compare_int64(const void* pa, const void* pb);
+
+extern void sfnt_iarray_mean_and_limits_int64(const int64_t* start, const int64_t* end,
+                               int64_t* mean_out, int64_t* min_out, int64_t* max_out);
+
+extern void sfnt_iarray_variance_int64(const int64_t* start, const int64_t* end,
+                        int64_t mean, int64_t* variance_out);
 
 /**********************************************************************
  * File / muxer convenience functions.

--- a/src/sfnt-pingpong.c
+++ b/src/sfnt-pingpong.c
@@ -121,12 +121,12 @@ static struct sfnt_cmd_line_opt cfg_opts[] = {
 
 
 struct stats {
-  int mean;
-  int min;
-  int median;
-  int max;
-  int percentile;
-  int stddev;
+  int64_t mean;
+  int64_t min;
+  int64_t median;
+  int64_t max;
+  int64_t percentile;
+  int64_t stddev;
 };
 
 
@@ -1085,13 +1085,13 @@ static void get_stats(struct stats* s, int64_t* results, int results_n)
   int64_t* results_end = results + results_n;
   int64_t variance;
 
-  qsort(results, results_n, sizeof(int), &sfnt_qsort_compare_int);
-  sfnt_iarray_mean_and_limits(results, results_end, &s->mean, &s->min, &s->max);
+  qsort(results, results_n, sizeof(int64_t), &sfnt_qsort_compare_int64);
+  sfnt_iarray_mean_and_limits_int64(results, results_end, &s->mean, &s->min, &s->max);
 
   s->median = results[results_n >> 1u];
-  s->percentile = results[(int) (results_n * cfg_percentile / 100)];
-  sfnt_iarray_variance(results, results_end, s->mean, &variance);
-  s->stddev = (int) sqrt((double) variance);
+  s->percentile = results[(int64_t) (results_n * cfg_percentile / 100)];
+  sfnt_iarray_variance_int64(results, results_end, s->mean, &variance);
+  s->stddev = (int64_t) sqrt((double) variance);
 }
 
 

--- a/src/sfnt-pingpong.c
+++ b/src/sfnt-pingpong.c
@@ -1069,7 +1069,8 @@ static void do_pings(int ss, int read_fd, int write_fd, int msg_size,
     sfnt_tsc(&start);
     do_ping(read_fd, write_fd, msg_size);
     sfnt_tsc(&stop);
-    results[i] = (int) sfnt_tsc_nsec(&tsc, stop - start - tsc.tsc_cost);
+    
+    results[i] = sfnt_tsc_nsec(&tsc, stop - start - tsc.tsc_cost);
     if( ! cfg_rtt )
       results[i] /= 2;
     if( cfg_sleep_gap )

--- a/src/sfnt-pingpong.c
+++ b/src/sfnt-pingpong.c
@@ -1051,7 +1051,7 @@ static int do_server2(int ss)
 
 
 static void do_pings(int ss, int read_fd, int write_fd, int msg_size,
-                     int iter, int* results)
+                     int iter, int64_t* results)
 {
   uint64_t start, stop;
   int i;
@@ -1080,9 +1080,9 @@ static void do_pings(int ss, int read_fd, int write_fd, int msg_size,
 }
 
 
-static void get_stats(struct stats* s, int* results, int results_n)
+static void get_stats(struct stats* s, int64_t* results, int results_n)
 {
-  int* results_end = results + results_n;
+  int64_t* results_end = results + results_n;
   int64_t variance;
 
   qsort(results, results_n, sizeof(int), &sfnt_qsort_compare_int);
@@ -1095,7 +1095,7 @@ static void get_stats(struct stats* s, int* results, int results_n)
 }
 
 
-static void write_raw_results(int msg_size, int* results, int results_n)
+static void write_raw_results(int msg_size, int64_t* results, int results_n)
 {
   char* fname = (char*) alloca(strlen(cfg_raw) + 30);
   FILE* f;
@@ -1105,15 +1105,15 @@ static void write_raw_results(int msg_size, int* results, int results_n)
     sfnt_err("ERROR: Could not open output file '%s'\n", fname);
     sfnt_fail_test();
   }
-  for( i = 0; i < results_n; ++i )
-    fprintf(f, "%d\n", results[i]);
+  for( i = 0; i < results_n; ++i)
+    fprintf(f, "%"PRId64"\n", results[i]);
   fclose(f);
 }
 
 
 static void run_test(int ss, int read_fd, int write_fd, int maxms, int minms,
                      int maxiter, int miniter, int* results_n, int msg_size,
-                     int* results)
+                     int64_t* results)
 {
   int n_this_time = miniter;
   uint64_t start, end, ticks;
@@ -1143,7 +1143,7 @@ static void run_test(int ss, int read_fd, int write_fd, int maxms, int minms,
 static void do_warmup(int ss, int read_fd, int write_fd)
 {
   int results_n = 0;
-  int* results;
+  int64_t* results;
 
   /* If the requested warmup timeout is large with respect to the number of
    * warmup iterations, the warmup would sit doing nothing after the requested
@@ -1168,7 +1168,7 @@ static void do_warmup(int ss, int read_fd, int write_fd)
 
 
 static void do_test(int ss, int read_fd, int write_fd,
-                    int msg_size, int* results)
+                    int msg_size, int64_t* results)
 {
   int results_n = 0;
   struct stats s;
@@ -1324,7 +1324,7 @@ static int do_client2(int ss, const char* hostport, int local)
   int read_fd, write_fd;
   char* server_ld_preload;
   int msg_size;
-  int* results;
+  int64_t* results;
   int i, one = 1;
   uint64_t old_tsc_hz;
 

--- a/src/sfnt-pingpong.c
+++ b/src/sfnt-pingpong.c
@@ -1180,8 +1180,8 @@ static void do_test(int ss, int read_fd, int write_fd,
   if( cfg_raw != NULL )
     write_raw_results(msg_size, results, results_n);
   get_stats(&s, results, results_n);
-  printf("\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\n", msg_size,
-         s.mean, s.min, s.median, s.max, s.percentile, s.stddev, results_n);
+  printf("\t%d\t%"PRId64"\t%"PRId64"\t%"PRId64"\t%"PRId64"\t%"PRId64"\t%"PRId64"\t%d\n",
+            msg_size, s.mean, s.min, s.median, s.max, s.percentile, s.stddev, results_n);
   fflush(stdout);
 }
 
@@ -1409,7 +1409,8 @@ static int do_client2(int ss, const char* hostport, int local)
     printf("# server LD_PRELOAD=%s\n", server_ld_preload);
   printf("# percentile=%g\n", (double) cfg_percentile);
   printf("#\n");
-  printf("#\tsize\tmean\tmin\tmedian\tmax\t%%ile\tstddev\titer\n");
+  printf("#\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+              "size", "mean", "min", "median", "max", "%ile", "stddev", "iter");
   fflush(stdout);
 
   if( fd_type & FDTF_STREAM ) {

--- a/src/sfnt_stats.c
+++ b/src/sfnt_stats.c
@@ -68,3 +68,66 @@ void sfnt_iarray_variance(const int* start, const int* end,
 
   *variance_out = sumsq / (end - start - 1);
 }
+
+/* Template for qsort requires int return, so instead of using subtraction as comparison
+   we return -1, 0 or 1 depending on if pa is less than, equal to, or greater than pb*/
+int sfnt_qsort_compare_int64(const void* pa, const void* pb)
+{
+  const int64_t* a = pa;
+  const int64_t* b = pb;
+  if(*a > *b) 
+    return 1;
+  else if(*a < *b) 
+    return -1;
+  else 
+    return 0;
+
+}
+
+void sfnt_iarray_mean_and_limits_int64(const int64_t* start, const int64_t* end,
+                               int64_t* mean_out, int64_t* min_out, int64_t* max_out)
+{
+  int64_t min, max;
+  int64_t sum;
+  const int64_t* i;
+
+  NT_ASSERT(end - start > 0);
+
+  sum = 0;
+  min = max = *start;
+
+  for( i = start; i != end; ++i ) {
+    if( *i < min )  min = *i;
+    else
+    if( *i > max )  max = *i;
+    sum += *i;
+  }
+
+  if( mean_out )  *mean_out = (int64_t) (sum / (end - start));
+  if( min_out  )  *min_out  = min;
+  if( max_out  )  *max_out  = max;
+}
+
+void sfnt_iarray_variance_int64(const int64_t* start, const int64_t* end,
+                        int64_t mean, int64_t* variance_out)
+{
+  int64_t sumsq, diff;
+  const int64_t* i;
+
+  NT_ASSERT(end - start > 0);
+  NT_ASSERT(variance_out);
+
+  if( end - start < 2 ) {
+    *variance_out = 0;
+    return;
+  }
+
+  sumsq = 0;
+
+  for( i = start; i != end; ++i ) {
+    diff = *i - mean;
+    sumsq += diff * diff;
+  }
+
+  *variance_out = sumsq / (end - start - 1);
+}


### PR DESCRIPTION
QAI-10345 detected negative latencies in the results table generated in sfnt-pingpong. 

Though, this only observed part of the main issue here - on rare occasions, the TSC delta would be large enough that it would overflow in signed 32-bit int space; whilst a negative number is an obvious indication of that, there were cases where this delta was so large that it actually overflowed into the positive space which would appear as a seemingly "sensible" result, which is particularly problematic.

Updating sfnt-pingpong to (signed) INT64 should be able to cover all of these detected significant delays, and have them be represented appropriately in the results table. This means that obtaining a negative result, or indeed a positive overflow result, is very unlikely. Though, if this ever occurred in signed 64-bit space, that would be an indication that something is very wrong. Using unsigned here could potentially mask that.  

Note that the 32-bit statistical functions are still used by sfnt-stream, which has not been changed for this ticket.

See the QAI-10345 ticket for recent test logs and example outputs of this version, as below.


	size	mean	min	median	max	%ile	stddev	iter
	1	3130	2478	3049	444179	8711	1839	100000
	1473	5773	5022	5553	178126	11924	2311	100000
	16384	21093	19796	20798	659991	28098	3556	50000
	65507	192250	69661	70758	1206990307	83666	12069188	10000

The max result for a size of 65507 would have caused an overflow in signed 32-bit space (casting 2413980614 to int before halving for one way trip time). With these changes, the results are reported appropriately.