### PR TITLE
cleanup: Fix a build time error

### DIFF
--- a/src/sfnt-pingpong.c
+++ b/src/sfnt-pingpong.c
@@ -2753,6 +2753,7 @@ static int do_client2(int ss, const char* hostport, int local)
   i = sfnt_sock_get_int(ss);
 
   do_warmup(ss, read_h, write_h);
+  old_tsc_hz = tsc.hz;
   NT_TRY(sfnt_tsc_get_params_end(&tsc_measure, &tsc, 50000));
   if( fabs((double)(int64_t)(tsc.hz - old_tsc_hz) / old_tsc_hz) > .01 )
     printf("# WARNING: tsc_hz changed to %"PRIu64" on recheck\n", tsc.hz);


### PR DESCRIPTION
This patch addresses:
```
$ ONLOAD_TREE=~/lab/onload_internal make
cc -Wall -Werror -g -DSFNT_VERSION='"no-version"' -DSFNT_SRC_CSUM='"cff624faa31624c320efae8ed4123a08"' -I/home/iteterev/lab/onload_internal/src/include    -c -o sfnt-pingpong.o sfnt-pingpong.c
sfnt-pingpong.c: In function ‘do_client2’:
sfnt-pingpong.c:2757:37: error: ‘old_tsc_hz’ is used uninitialized in this function [-Werror=uninitialized]
 2757 |   if( fabs((double)(int64_t)(tsc.hz - old_tsc_hz) / old_tsc_hz) > .01 )
      |                             ~~~~~~~~^~~~~~~~~~~~~
cc1: all warnings being treated as errors
make: *** [<builtin>: sfnt-pingpong.o] Error 1
```
It is a trivial fix that adds one line of code lost in f4325a4.