### PR TITLE
QAI-10345: Fix negative std-dev in sfnt-pingpong

### DIFF
--- a/src/sfnettest.h
+++ b/src/sfnettest.h
@@ -304,7 +304,7 @@ extern void sfnt_iarray_mean_and_limits_int64(const int64_t* start, const int64_
                                int64_t* mean_out, int64_t* min_out, int64_t* max_out);
 
 extern void sfnt_iarray_variance_int64(const int64_t* start, const int64_t* end,
-                        int64_t mean, int64_t* variance_out);
+                        int64_t mean, double* variance_out);
 
 /**********************************************************************
  * File / muxer convenience functions.

--- a/src/sfnt-pingpong.c
+++ b/src/sfnt-pingpong.c
@@ -126,7 +126,7 @@ struct stats {
   int64_t median;
   int64_t max;
   int64_t percentile;
-  int64_t stddev;
+  uint64_t stddev;
 };
 
 
@@ -1084,7 +1084,7 @@ static void do_pings(int ss, int read_fd, int write_fd, int msg_size,
 static void get_stats(struct stats* s, int64_t* results, int results_n)
 {
   int64_t* results_end = results + results_n;
-  int64_t variance;
+  double variance;
 
   qsort(results, results_n, sizeof(int64_t), &sfnt_qsort_compare_int64);
   sfnt_iarray_mean_and_limits_int64(results, results_end, &s->mean, &s->min, &s->max);
@@ -1092,7 +1092,7 @@ static void get_stats(struct stats* s, int64_t* results, int results_n)
   s->median = results[results_n >> 1u];
   s->percentile = results[(int64_t) (results_n * cfg_percentile / 100)];
   sfnt_iarray_variance_int64(results, results_end, s->mean, &variance);
-  s->stddev = (int64_t) sqrt((double) variance);
+  s->stddev = (uint64_t) sqrt(variance);
 }
 
 

--- a/src/sfnt_stats.c
+++ b/src/sfnt_stats.c
@@ -109,9 +109,10 @@ void sfnt_iarray_mean_and_limits_int64(const int64_t* start, const int64_t* end,
 }
 
 void sfnt_iarray_variance_int64(const int64_t* start, const int64_t* end,
-                        int64_t mean, int64_t* variance_out)
+                        int64_t mean, double* variance_out)
 {
-  int64_t sumsq, diff;
+  double sumsq;
+  int64_t diff;
   const int64_t* i;
 
   NT_ASSERT(end - start > 0);


### PR DESCRIPTION
The std-dev result for runs of sfnt-pingpong are sometimes negative. This is caused, in the variance calculation, by `sumsq` being a signed 64-bit int, so when `diff * diff` is calculated this may overflow in positive 64-bit space. Example result of this is below: 

```
size	mean	min	median	max	%ile	stddev	iter
1	3521	3045	3561	426646	3894	1594	100000
1448	5043	4561	5045	20970	5447	301	100000
1449	6096	5476	6126	20263	6511	339	60000
65535	1452684	69607	71317	2432235344	80695	-9223372036854775808	10000
```

Changing the type of `sumsq` and `variance` to ~~unsigned~~ double should prevent this, by sacrificing some precision.
