### PR TITLE
QAI-10987: Increase default 'rtt_iter' to stabilise return latency

### DIFF
--- a/src/sfnt-stream.c
+++ b/src/sfnt-stream.c
@@ -47,7 +47,7 @@ static const char* cfg_tcpc_serv;
 static const char* cfg_affinity[2];
 static int         cfg_nodelay;
 static unsigned    cfg_busy_poll[2];
-static unsigned    cfg_rtt_iter = 10000;
+static unsigned    cfg_rtt_iter = 100000;
 static int         cfg_debug;
 static unsigned    cfg_v6only[2];
 static int         cfg_ipv4;


### PR DESCRIPTION
Negative values are commonly generated when running the sfnt-stream app, as a result of the calculation done in rec_latency_ns which subtracts the return latency mean (obtained in warmup) from the actual latency results (for one way trip). rtt_iter determines how many warmup iterations the app does to obtain this mean value; at its current default of 10000, negatives are generated frequently which makes the results unreliable at this value.

This increases the default to 100000, which reflects the warmup period for sfnt-pingpong. This should stabilise the mean value calculated, significantly reducing the likelihood of negatives being generated.