### PR TITLE
ON-14996: prepare sfnettest for version bump

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (c) 2023 Advanced Micro Devices, Inc.
+
+* @Xilinx-CNS/cns-onload @driddoch-xilinx @andrewle-xilinx @pdunning-xilinx

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# SPDX-FileCopyrightText: Copyright (c) 2011-2013 Solarflare Communications Inc.
+
 *~
 *.orig
 *.rej

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# SPDX-FileCopyrightText: Copyright (c) 2012 Solarflare Communications Inc.
 
 sfnettest-1.5.0
 ---------------
@@ -18,5 +20,3 @@ sfnettest-1.5.0
 - Added option --ttl to set IP_TTL and IP_MULTICAST_TTL.
 - Fix minor problem handling command line args.
 - Improve error message when process affinity support is not available.
-
-(C) Copyright 2011-2019 Xilinx, Inc.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,18 @@
 # SPDX-License-Identifier: GPL-2.0-only
-# SPDX-FileCopyrightText: Copyright (c) 2012 Solarflare Communications Inc.
+# SPDX-FileCopyrightText: Copyright (c) 2012-2023 Advanced Micro Devices, Inc.
+
+sfnettest-1.6.0
+---------------
+
+- Use 64-bit values to avoid overflow with large nanosecond times or variances
+- Use monotonic clock for timing
+- Add IPv6 support
+- Add --warmupiter option for a warm-up phase to sfnt-pingpong
+- Add --busy-poll option
+- Add asymmetric counts, e.g. --n-pings="200;1"
+- Add --more flag to control MSG_MORE
+- Extend operating system and compiler compatibility
+- Fix various other issues
 
 sfnettest-1.5.0
 ---------------

--- a/src/rules_pre.mk
+++ b/src/rules_pre.mk
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# SPDX-FileCopyrightText: Copyright (c) 2011 Solarflare Communications Inc.
+
 # Set per OS flags
 ifeq ($(shell uname -s),Linux)
 OS_LINUX := 1


### PR DESCRIPTION
Prepare the sfnettest repo for bumping the version number after 11 years of improvements which are often referenced by commit id in test or examples. This is an appropriate time to make the change as this repo is consumed by the Kubernetes Onload sfnettest example load container definition.

Please do suggestion any changes to the changelog in particular.