### PR TITLE
ON-15185: Add Dockerfile & build flow

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# (c) Copyright 2023 Advanced Micro Devices, Inc.
+name: "Container Image"
+
+on:
+  workflow_dispatch:
+    inputs:
+      registry-prefix:
+        description: Registry host and org
+        type: string
+      version:
+        description: Version of sfnettest
+        type: string
+      release-tag:
+        description: Release tag (no -dev suffix)
+        type: boolean
+        default: false
+      builder-ubi-image:
+        description: Base image for builder (override workflow)
+        type: string
+      ubi-image:
+        description: Base image (override workflow)
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+jobs:
+  container-build:
+    name: Container Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      REGISTRY_PREFIX: ${{ inputs.registry-prefix }}
+      SFNT_VERSION: ${{ inputs.version }}
+      IMAGE_TAG_SUFFIX: ${{ inputs.release-tag == false && '-dev' || '' }}
+      BUILDER_UBI_IMAGE: ${{ inputs.builder-ubi-image || 'registry.access.redhat.com/ubi9-minimal:9.3' }}
+      UBI_IMAGE: ${{ inputs.ubi-image || 'registry.access.redhat.com/ubi9-micro:9.3' }}
+    steps:
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Metadata - version
+      id: meta-version
+      uses: docker/metadata-action@v5
+      with:
+        images: sfnettest
+        tags: |
+          type=match,pattern=sfnettest-([\d\.-]+),group=1
+          type=sha,prefix=git-,format=short
+
+    - name: Metadata - env
+      run: |
+        repo="${GITHUB_REPOSITORY@L}"
+        echo "REGISTRY_PREFIX=${REGISTRY_PREFIX:-ghcr.io/$repo}" >> "$GITHUB_ENV"
+        echo "SFNT_VERSION=${SFNT_VERSION:-$REPO_VERSION}" >> "$GITHUB_ENV"
+      env:
+        REPO_VERSION: ${{ fromJSON(steps.meta-version.outputs.json).labels['org.opencontainers.image.version'] }}
+
+    - name: Metadata - Docker tagging
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: |
+          ${{ env.REGISTRY_PREFIX }}/sfnettest
+        tags: |
+          type=ref,event=branch,suffix=${{ env.IMAGE_TAG_SUFFIX }}
+          type=ref,event=tag,suffix=${{ env.IMAGE_TAG_SUFFIX }}
+          type=ref,event=pr,prefix=pr-
+          type=sha,prefix=git-,format=short
+          type=match,pattern=sfnettest-([\d\.-]+),group=1,suffix=${{ env.IMAGE_TAG_SUFFIX }}
+
+    - if: ${{ contains(env.REGISTRY_PREFIX, 'ghcr.io') }}
+      name: Login to registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
+
+    - name: Build
+      id: build
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: Dockerfile
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        push: true
+        build-args: |
+          SFNT_VERSION=${{ env.SFNT_VERSION }}
+          BUILDER_UBI_IMAGE=${{ env.BUILDER_UBI_IMAGE }}
+          UBI_IMAGE=${{ env.UBI_IMAGE }}

--- a/ContainerFileNotice
+++ b/ContainerFileNotice
@@ -1,0 +1,43 @@
+NOTICE - BY INVOKING THIS SCRIPT AND USING THE SOFTWARE INSTALLED BY THE
+SCRIPT, YOU AGREE ON BEHALF OF YOURSELF AND YOUR EMPLOYER (IF APPLICABLE) TO BE
+BOUND TO THE LICENSE AGREEMENTS APPLICABLE TO THE PACKAGES IDENTIFIED BELOW
+THAT YOU INSTALL BY RUNNING THE SCRIPT. YOU UNDERSTAND THAT THE INSTALLATION OF
+THE PACKAGES LISTED BELOW MAY ALSO RESULT IN THE INSTALLATION ON YOUR SYSTEM OF
+ADDITIONAL PACKAGES NOT LISTED BELOW IN ORDER TO OPERATE (EACH, A
+‘DEPENDENCY’). ADVANCED MICRO DEVICES, INC., ON BEHALF OF ITSELF AND ITS
+SUBSIDIARIES AND AFFILIATES, DOES NOT GRANT TO YOU ANY RIGHTS OR LICENSES TO
+ANY SUCH DEPENDENCY. THE SCRIPT ITSELF IS LICENSED TO YOU SUBJECT TO THE
+FOLLOWING TERMS:
+
+Copyright © 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+
+These files (Dockerfile) are licensed under the following license terms (GPL-2.0-only):
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the “Software”), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+These files (Dockerfile) pull in the following packages subject
+to the licenses identified below.
+
+Dockerfile:
+
+| Package, Version                                            | License      | URL                                                                                    |
+|-------------------------------------------------------------+--------------+----------------------------------------------------------------------------------------|
+| Red Hat Universal Basic Image, 9                            | UBI EULA     | https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf |
+|                                                             | + Various    |                                                                                        |
+|-------------------------------------------------------------+--------------+----------------------------------------------------------------------------------------|

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+# hadolint global ignore=DL3006,DL3040,DL3041
+ARG BUILDER_UBI_IMAGE=redhat/ubi9-minimal:9.3
+ARG UBI_IMAGE=redhat/ubi9-micro:9.3
+
+FROM $BUILDER_UBI_IMAGE as builder
+ARG SFNT_VERSION
+ARG SFNT_BUILD_PARAMS
+WORKDIR /opt/sfnettest
+COPY src LICENSE /opt/sfnettest/
+RUN microdnf install -y make findutils gcc && \
+    make $SFNT_BUILD_PARAMS
+
+FROM $UBI_IMAGE
+ARG SFNT_VERSION
+LABEL \
+  name="sfnettest" \
+  summary="sfnettest" \
+  description="sfnt-stream & sfnt-pingpong" \
+  maintainer="Advanced Micro Devices, Inc." \
+  vendor="Advanced Micro Devices, Inc." \
+  version="$SFNT_VERSION" \
+  release="$SFNT_VERSION"
+COPY --from=builder /opt/sfnettest/sfnt-stream /opt/sfnettest/sfnt-pingpong /bin/
+COPY --from=builder /opt/sfnettest/LICENSE /licenses/
+USER 1001
+ENV SFNT_AVOID_FORK=1
+ENTRYPOINT [ "/bin/sfnt-pingpong" ]

--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ Instructions on running each tool:
 * [`sfnt-pingpong`](README.sfnt-pingpong.md)
 * [`sfnt-stream`](README.sfnt-stream.md)
 
+Container
+---------
+
+[Dockerfile](Dockerfile) includes both tools.
+
+```sh
+docker build --network=host -t sfnettest .
+docker run --network=host sfnettest --help # sfnt-pingpong is default entrypoint
+```
+
 Copyright
 ---------
 


### PR DESCRIPTION
Bare bones container image binary distribution.

Added for Kubernetes Onload December GA release but not dependant on Kubernetes or Onload. Internal [discussion](https://xilinx-cns.slack.com/archives/C04J5E8KD5W/p1699556018273669) on entrypoint.

If anyone remembers the intentioned release process (involving `SFNT_RELEASE_CSUM` env var) do share. Currently the version gets harmless `-modified` suffix. I could improvise but would rather know what was intentioned.

Container image passes Redhat Preflight.

Workflow [builds](https://github.com/pcolledg-amd/cns-sfnettest/actions/runs/6823832404/job/18558519840) and [pushes](https://github.com/pcolledg-amd/cns-sfnettest/pkgs/container/cns-sfnettest%2Fsfnettest). @ivatet-amd has tested the built image in Kubernetes cluster. We'll be putting this PR though Legal.