### PR TITLE
cleanup: Simpler SFNT_VERSION from Git

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -48,7 +48,7 @@ jobs:
         images: sfnettest
         tags: |
           type=match,pattern=sfnettest-([\d\.-]+),group=1
-          type=sha,prefix=git-,format=short
+          type=sha,format=short
 
     - name: Metadata - env
       run: |
@@ -92,3 +92,4 @@ jobs:
           SFNT_VERSION=${{ env.SFNT_VERSION }}
           BUILDER_UBI_IMAGE=${{ env.BUILDER_UBI_IMAGE }}
           UBI_IMAGE=${{ env.UBI_IMAGE }}
+          SFNT_BUILD_PARAMS=RELEASE_VERSION_MK=true

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 *.sdf
 *.opensdf
 *.suo
+version.mk
 sfnt-pingpong
 sfnt-stream
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -57,22 +57,19 @@ endif
 sfnt-stream: LIBS += -lpthread
 $(APPS): libsfnettest.a
 
-
 # TODO: Make this stuff VPATH friendly.
 SFNT_SRC_CSUM	:= $(shell find . -name '*.[ch]' | LC_ALL=C sort | \
                              xargs cat | $(MD5SUM) | sed 's/ .*//')
+ifdef RELEASE_VERSION_MK
+version.mk:
+	echo "SFNT_RELEASE_CSUM := $(SFNT_SRC_CSUM)" > version.mk
+endif
 sinclude version.mk
-ifeq ($(SFNT_VERSION),)
-
-SFNT_VERSION	:= $(shell hg id --id 2>/dev/null || \
-  ( test -f ../.hg_archival.txt && \
-    awk '/node:/{print $$2}' ../.hg_archival.txt ) || \
-  echo no-version)
-else
+SFNT_VERSION	?= $(shell git rev-parse --short=7 HEAD || echo no-version)
 ifneq ($(SFNT_RELEASE_CSUM),$(SFNT_SRC_CSUM))
-SFNT_VERSION	:= $(SFNT_VERSION)-modified
+override SFNT_VERSION := $(SFNT_VERSION)-modified
 endif
-endif
+
 CPPFLAGS	+= -DSFNT_VERSION='"$(SFNT_VERSION)"'
 CPPFLAGS	+= -DSFNT_SRC_CSUM='"$(SFNT_SRC_CSUM)"'
 
@@ -84,3 +81,4 @@ endif
 
 
 include rules.mk
+


### PR DESCRIPTION
Plain `make` will now version using Git commit digest instead of Mercurial and add `-modified` by default for non-releases.

- Mercurial swapped for Git in Makefile
- `$SFNT_VERSION` equal/defined logic simplified. Before, an empty `export SFNT_VERSION=` resulted in differing behaviour (a version equalling just `-modified`).
- *All* builds missing release checksum are now `-modified`
- Add guesstimated `version.mk` generator. To release, set `RELEASE_VERSION_MK=true` or write a `version.mk` as before (so I presume). Note: variable `RELEASE_VERSION_MK` required as otherwise `sinclude version.mk` triggers the target by that name.
- Workflow builds all as releases by default
