### PR TITLE
ON-16672: Specify address family when binding socket

### DIFF
--- a/src/sfnt-stream.c
+++ b/src/sfnt-stream.c
@@ -1590,13 +1590,15 @@ static void* client_rx_thread(void* arg)
   crx->recs_n = 0;
   switch( handle_type ) {
   case HT_UDP:
-    NT_TRY2(crx->handle.fd, socket(PF_INET, SOCK_DGRAM, 0));
+    NT_TRY2(crx->handle.fd, socket(crx->af, SOCK_DGRAM, 0));
     if (crx->af == AF_INET6) {
       struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *) &ss;
+      sin6->sin6_family = AF_INET6;
       sin6->sin6_addr = in6addr_any;
       socklen = sizeof(*sin6);
     } else {
       struct sockaddr_in *sin = (struct sockaddr_in *) &ss;
+      sin->sin_family = AF_INET;
       sin->sin_addr.s_addr = INADDR_ANY;
       socklen = sizeof(*sin);
     }


### PR DESCRIPTION
The kernel lets us get away without specifying the family, but we should really
be doing so. In addition we now specify the requested family when creating the
socket which fixes IPv6 using the kernel.

I've raised https://jira.xilinx.com/browse/ON-16671 to cover making onload more lenient in line with the kernel, but we probably want to do this to work with unfixed onload versions.

Testing done:
Kernel + IPv4
<details>
  <summary>Before (ok) </summary>

```
sianj@dellr250aj:~$ sfnt-stream
sfnt-stream: server: waiting for client to connect...
sfnt-stream: server: client connected
sfnt-stream: server: client at 192.168.130.255:46415
```
```
$ sfnt-stream udp dellr250aj-l
...
sfnt-stream: client: TX rate is 76% of target; stopping
```

</details>
<details>
  <summary>After (ok)</summary>

```
sianj@dellr250aj:~$ sfnt-stream
sfnt-stream: server: waiting for client to connect...
sfnt-stream: server: client connected
sfnt-stream: server: client at 192.168.130.255:34029
```
```
sianj@dellr250ai:~$ sfnt-stream udp dellr250aj-l
...
sfnt-stream: client: TX rate is 77% of target; stopping
```
</details>

Kernel + IPv6:
<details>
  <summary>Before (failed) </summary>

```
sianj@dellr250aj:~$ sfnt-stream
sfnt-stream: server: waiting for client to connect...
sfnt-stream: server: client connected
sfnt-stream: server: client at [fd00::200:c0ff:fea8:82ff]:37942
```
```
sianj@dellr250ai:~$ sfnt-stream udp dellr250aj-6l
...
ERROR: Timeout waiting for synchronisation message
ERROR: Test failed.
```
</details>
<details>
  <summary>After (ok)</summary>

```
sianj@dellr250aj:~$ sfnt-stream
sfnt-stream: server: waiting for client to connect...
sfnt-stream: server: client connected
sfnt-stream: server: client at [fd00::200:c0ff:fea8:82ff]:58748
```
```
sianj@dellr250ai:~$ sfnt-stream udp dellr250aj-6l
...
sfnt-stream: client: TX rate is 84% of target; stopping
```
</details>

Onload + IPv4
<details>
  <summary>Before (failed) </summary>

```
sianj@dellr250aj:~$ onload sfnt-stream
onload: app-handler: sfnt-stream (/home/sianj/source/xilinx-cns/onload_internal/scripts/onload_apps/sfnt-stream)
onload: Use -v option to see which tuning options are being automatically applied.
onload: Note: Disabling CTPIO cut-through because only adapters running at 10GbE benefit from it
oo:sfnt-stream[98703]: Using Onload 0a967e26aa 2025-06-13 master  [0,-t98703]
oo:sfnt-stream[98703]: Copyright (c) 2002-2025 Advanced Micro Devices, Inc.
sfnt-stream: server: waiting for client to connect...
sfnt-stream: server: client connected
ERROR: at sfnt_socket.c:421
ERROR: (send(fd, &v32, sizeof(v32), 0), ==, sizeof(v32)) failed
ERROR: send(fd, &v32, sizeof(v32), 0)=-1 sizeof(v32)=4 errno=(104 Connection reset by peer)
ERROR: Test failed.
```
```
sianj@dellr250ai:~$ onload sfnt-stream udp dellr250aj-l
onload: app-handler: sfnt-stream (/home/sianj/source/xilinx-cns/onload_internal/scripts/onload_apps/sfnt-stream)
onload: Use -v option to see which tuning options are being automatically applied.
onload: Note: Disabling CTPIO cut-through because only adapters running at 10GbE benefit from it
oo:sfnt-stream[16767]: Using Onload 406842c371 2025-06-13 reviews/sianj-xilinx/ON-16330_icmp6 cloud [7,-t16767]
oo:sfnt-stream[16767]: Copyright (c) 2002-2025 Advanced Micro Devices, Inc.
oo:sfnt-stream[16767]: Using Onload 406842c371 2025-06-13 reviews/sianj-xilinx/ON-16330_icmp6 cloud [1,-t16829]
oo:sfnt-stream[16767]: Copyright (c) 2002-2025 Advanced Micro Devices, Inc.
ERROR: at sfnt-stream.c:1603
ERROR: bind(crx->handle.fd, (const struct sockaddr*) &ss, socklen) failed
ERROR: rc=-1 errno=(97 Address family not supported by protocol)
ERROR: Test failed.
```
</details>
<details>
  <summary>After (ok)</summary>

```
sianj@dellr250aj:~$ onload sfnt-stream
onload: app-handler: sfnt-stream (/home/sianj/source/xilinx-cns/onload_internal/scripts/onload_apps/sfnt-stream)
onload: Use -v option to see which tuning options are being automatically applied.
onload: Note: Disabling CTPIO cut-through because only adapters running at 10GbE benefit from it
oo:sfnt-stream[99060]: Using Onload 0a967e26aa 2025-06-13 master  [3,-t99060]
oo:sfnt-stream[99060]: Copyright (c) 2002-2025 Advanced Micro Devices, Inc.
sfnt-stream: server: waiting for client to connect...
sfnt-stream: server: client connected
sfnt-stream: server: client at 192.168.130.255:39324
```
```
sianj@dellr250ai:~$ onload sfnt-stream udp dellr250aj-l
...
sfnt-stream: client: TX rate is 89% of target; stopping
```
</details>

Onload + IPv6
<details>
  <summary>Before (failed) </summary>

```
sianj@dellr250aj:~$ onload sfnt-stream
onload: app-handler: sfnt-stream (/home/sianj/source/xilinx-cns/onload_internal/scripts/onload_apps/sfnt-stream)
onload: Use -v option to see which tuning options are being automatically applied.
onload: Note: Disabling CTPIO cut-through because only adapters running at 10GbE benefit from it
oo:sfnt-stream[98775]: Using Onload 0a967e26aa 2025-06-13 master  [1,-t98775]
oo:sfnt-stream[98775]: Copyright (c) 2002-2025 Advanced Micro Devices, Inc.
sfnt-stream: server: waiting for client to connect...
sfnt-stream: server: client connected
ERROR: at sfnt_socket.c:421
ERROR: (send(fd, &v32, sizeof(v32), 0), ==, sizeof(v32)) failed
ERROR: send(fd, &v32, sizeof(v32), 0)=-1 sizeof(v32)=4 errno=(104 Connection reset by peer)
ERROR: Test failed.
```
```
sianj@dellr250ai:~$ onload sfnt-stream udp dellr250aj-6l
onload: app-handler: sfnt-stream (/home/sianj/source/xilinx-cns/onload_internal/scripts/onload_apps/sfnt-stream)
onload: Use -v option to see which tuning options are being automatically applied.
onload: Note: Disabling CTPIO cut-through because only adapters running at 10GbE benefit from it
oo:sfnt-stream[16835]: Using Onload 406842c371 2025-06-13 reviews/sianj-xilinx/ON-16330_icmp6 cloud [4,-t16835]
oo:sfnt-stream[16835]: Copyright (c) 2002-2025 Advanced Micro Devices, Inc.
oo:sfnt-stream[16835]: Using Onload 406842c371 2025-06-13 reviews/sianj-xilinx/ON-16330_icmp6 cloud [3,-t16896]
oo:sfnt-stream[16835]: Copyright (c) 2002-2025 Advanced Micro Devices, Inc.
ERROR: at sfnt-stream.c:1603
ERROR: bind(crx->handle.fd, (const struct sockaddr*) &ss, socklen) failed
ERROR: rc=-1 errno=(97 Address family not supported by protocol)
ERROR: Test failed.
```
</details>
<details>
  <summary>After (ok)</summary>

```
sianj@dellr250aj:~$ onload sfnt-stream
onload: app-handler: sfnt-stream (/home/sianj/source/xilinx-cns/onload_internal/scripts/onload_apps/sfnt-stream)
onload: Use -v option to see which tuning options are being automatically applied.
onload: Note: Disabling CTPIO cut-through because only adapters running at 10GbE benefit from it
oo:sfnt-stream[98987]: Using Onload 0a967e26aa 2025-06-13 master  [2,-t98987]
oo:sfnt-stream[98987]: Copyright (c) 2002-2025 Advanced Micro Devices, Inc.
sfnt-stream: server: waiting for client to connect...
sfnt-stream: server: client connected
sfnt-stream: server: client at [fd00::200:c0ff:fea8:82ff]:37540
```
```
sianj@dellr250ai:~$ onload sfnt-stream udp dellr250aj-6l
...
sfnt-stream: client: TX rate is 89% of target; stopping
```
</details>