### PR TITLE
ON-16717: Add bogomips option for tsc calibration

### DIFF
--- a/src/sfnettest.h
+++ b/src/sfnettest.h
@@ -260,6 +260,9 @@ extern int sfnt_tsc_get_params_end(const struct sfnt_tsc_measure* measure,
                                    struct sfnt_tsc_params* params,
                                    int interval_usec);
 
+#if defined(__linux__)
+extern int sfnt_tsc_bogomips(struct sfnt_tsc_params* params);
+#endif
 /* Convert tsc delta to milliseconds. */
 extern int64_t sfnt_tsc_msec(const struct sfnt_tsc_params*, int64_t tsc);
 

--- a/src/sfnt_tsc.c
+++ b/src/sfnt_tsc.c
@@ -12,6 +12,13 @@
 #include "sfnettest.h"
 
 
+#if defined(__linux__)
+/* Assume conversion from  bogomips to hz is multiply by 500,000.
+ * True for recent x86_64 CPUs.
+ * TODO: Implement platform independence. */
+#define BOGOMIPS2HZ 500000
+#endif
+
 static void measure_begin(struct sfnt_tsc_measure* measure)
 {
   uint64_t t_s;
@@ -109,6 +116,24 @@ int sfnt_tsc_get_params_end(const struct sfnt_tsc_measure* measure,
   return 0;
 }
 
+#if defined(__linux__)
+int sfnt_tsc_bogomips(struct sfnt_tsc_params* params)
+{
+  double frequency;
+  char buf[128];
+  FILE* f;
+  params->tsc_cost = measure_tsc();
+  NT_TEST((f = fopen("/proc/cpuinfo", "r")) != NULL);
+  while( 1 ) {
+    NT_TEST(fgets(buf, sizeof(buf), f) != NULL);
+    if( sscanf(buf, "bogomips : %lf", &frequency) == 1 ) {
+      fclose(f);
+      params->hz = (uint64_t)(frequency * BOGOMIPS2HZ);
+      return 0;
+    }
+  }
+}
+#endif
 
 int64_t sfnt_tsc_msec(const struct sfnt_tsc_params* params, int64_t tsc)
 {


### PR DESCRIPTION
This commit adds the option to use the results of reading the bogomips value from /proc/cpuinfo and calculating the CPU HZ from this. This is a Linux only option and is an alternative to the built-in TSC_HZ calculations. It aligns the functionality with TCPDirect.


Testing done:

Three runs of sfnt-pingpong of both UDP and TCP on X2 with and without the option for sizes 16-32. Taking the average results of the three different tests. In the end the differences between individual runs were larger than the difference between the ones with the option and without.


|size | UDP Bogomips | UDP | UDP Diff | TCP Bogomips | TCP | TCP Diff|
|-- | -- | -- | -- | -- | -- | --|
|16 | 1044 | 1044 | 0 | 1172 | 1171 | 1|
|17 | 1044 | 1044 | -1 | 1173 | 1172 | 0|
|18 | 1040 | 1041 | -1 | 1171 | 1171 | 1|
|19 | 1060 | 1059 | 1 | 1173 | 1173 | 1|
|20 | 1060 | 1058 | 1 | 1173 | 1172 | 1|
|21 | 1060 | 1059 | 1 | 1174 | 1173 | 1|
|22 | 1060 | 1059 | 2 | 1172 | 1172 | 0|
|23 | 1076 | 1075 | 1 | 1180 | 1179 | 1|
|24 | 1075 | 1074 | 1 | 1179 | 1178 | 1|
|25 | 1076 | 1075 | 1 | 1180 | 1179 | 1|
|26 | 1076 | 1075 | 2 | 1178 | 1177 | 1|
|27 | 1078 | 1077 | 1 | 1180 | 1179 | 1|
|28 | 1077 | 1077 | 1 | 1180 | 1179 | 1|
|29 | 1079 | 1077 | 1 | 1181 | 1180 | 1|
|30 | 1079 | 1077 | 2 | 1180 | 1178 | 2|
|31 | 1084 | 1083 | 2 | 1187 | 1186 | 1|
|32 | 1084 | 1084 | 0 | 1186 | 1185 | 1|

The TSC_HZ with the bogomips options is always a fixed value (on the server) of: 3499810000
Without it can fluctuate a bit (shown below): 
| Test | 1 | 2 | 3|
|-- | -- | -- | -- |
|UDP | 3499992650	| 3499992977	| 3499993463|
|TCP | 3499993070	| 3499992870	| 3499992946|
|Average| 3499992996


Example of RAW test bogomips
```
[dellr630ag:src]$taskset -c 1 onload ./sfnt-pingpong --bogomips --affinity '3;3' --sizes 16-32 udp 192.168.136.229
onload: app-handler: sfnt-pingpong (/home/ibeecraf/git/onload_internal/scripts/onload_apps/sfnt-pingpong)
onload: Use -v option to see which tuning options are being automatically applied.
onload: Warning: CTPIO cut-through is enabled, but the link speed of some adapters could not be determined. If latency-sensitive traffic is using an adapter running at a speed other than 10GbE then use EF_CTPIO_MODE=sf for best results
oo:sfnt-pingpong[166226]: Using Onload c3f484d37c 2025-10-21 master  [3]
oo:sfnt-pingpong[166226]: Copyright (c) 2002-2025 Advanced Micro Devices, Inc.
# cmdline: ./sfnt-pingpong --bogomips --affinity 3;3 --sizes 16-32 udp 192.168.136.229
# version: 8db83a9-modified
# src: 43926a5d22237b78c74789bb8fd72ef5
# tsc_hz: 3499810000
# LD_PRELOAD=/home/ibeecraf/git/onload_internal/build/gnu_x86_64/lib/transport/unix/libcitransport0.so
# EF_CTPIO_SWITCH_BYPASS=1
# EF_POLL_USEC=100000
# EF_TCP_FASTSTART_INIT=0
# EF_CTPIO_MODE=ct
# EF_TCP_FASTSTART_IDLE=0
# EF_EPOLL_MT_SAFE=1
# server LD_PRELOAD=/home/ibeecraf/git/onload_internal/build/gnu_x86_64/lib/transport/unix/libcitransport0.so
# percentile=99
#
#       size    mean    min     median  max     %ile    stddev  iter
        16      1043    975     1037    5600    1138    28      1000000
        17      1043    975     1037    11342   1135    30      1000000
        18      1039    970     1034    11635   1131    30      1000000
        19      1062    991     1057    8000    1154    28      1000000
        20      1061    995     1056    8436    1153    28      1000000
        21      1062    996     1056    7917    1154    28      1000000
        22      1062    995     1056    11215   1155    31      1000000
        23      1078    1016    1075    9493    1118    23      1000000
        24      1077    1019    1074    8149    1117    21      1000000
        25      1077    1023    1074    7848    1118    21      1000000
        26      1078    1015    1075    8080    1120    22      1000000
        27      1079    1013    1077    8020    1120    21      1000000
        28      1080    1027    1077    10030   1123    23      1000000
        29      1080    1020    1077    8230    1120    21      1000000
        30      1080    1018    1077    8493    1120    22      1000000
        31      1086    1030    1085    9015    1128    22      1000000
        32      1086    1024    1084    8385    1127    22      1000000
```
Example without the option:
```
[dellr630ag:src]$taskset -c 1 onload ./sfnt-pingpong --affinity '3;3' --sizes 16-32 udp 192.168.136.229
onload: app-handler: sfnt-pingpong (/home/ibeecraf/git/onload_internal/scripts/onload_apps/sfnt-pingpong)
onload: Use -v option to see which tuning options are being automatically applied.
onload: Warning: CTPIO cut-through is enabled, but the link speed of some adapters could not be determined. If latency-sensitive traffic is using an adapter running at a speed other than 10GbE then use EF_CTPIO_MODE=sf for best results
oo:sfnt-pingpong[166888]: Using Onload c3f484d37c 2025-10-21 master  [4]
oo:sfnt-pingpong[166888]: Copyright (c) 2002-2025 Advanced Micro Devices, Inc.
# cmdline: ./sfnt-pingpong --affinity 3;3 --sizes 16-32 udp 192.168.136.229
# version: 8db83a9-modified
# src: 43926a5d22237b78c74789bb8fd72ef5
# tsc_hz: 3499993463
# LD_PRELOAD=/home/ibeecraf/git/onload_internal/build/gnu_x86_64/lib/transport/unix/libcitransport0.so
# EF_CTPIO_SWITCH_BYPASS=1
# EF_POLL_USEC=100000
# EF_TCP_FASTSTART_INIT=0
# EF_CTPIO_MODE=ct
# EF_TCP_FASTSTART_IDLE=0
# EF_EPOLL_MT_SAFE=1
# server LD_PRELOAD=/home/ibeecraf/git/onload_internal/build/gnu_x86_64/lib/transport/unix/libcitransport0.so
# percentile=99
#
#       size    mean    min     median  max     %ile    stddev  iter
        16      1043    975     1037    5352    1139    29      1000000
        17      1043    977     1037    9319    1136    29      1000000
        18      1040    969     1034    8635    1132    29      1000000
        19      1056    989     1052    7813    1150    29      1000000
        20      1055    988     1050    11652   1148    31      1000000
        21      1056    991     1051    10133   1148    30      1000000
        22      1055    985     1050    7917    1147    29      1000000
        23      1071    1009    1068    8301    1113    21      1000000
        24      1070    1004    1067    8056    1111    21      1000000
        25      1071    1009    1069    8009    1114    21      1000000
        26      1071    1012    1069    8073    1112    21      1000000
        27      1073    1009    1070    9081    1115    24      1000000
        28      1073    1009    1070    8142    1116    22      1000000
        29      1073    1011    1071    8581    1117    22      1000000
        30      1072    1007    1070    7860    1113    21      1000000
        31      1078    1013    1077    9834    1120    22      1000000
        32      1079    1019    1078    8070    1121    22      1000000
```