### PR TITLE
ON-16717: avoid tsc_hz calculation wrap when end too long after start

### DIFF
--- a/src/sfnt_tsc.c
+++ b/src/sfnt_tsc.c
@@ -67,7 +67,7 @@ static uint64_t measure_end(const struct sfnt_tsc_measure* measure,
   /* ?? TODO: handle this better */
   NT_TEST(skew == 0);
 
-  return (tsc_e - tsc_s) * t_freq / ticks;
+  return (uint64_t)(((tsc_e - tsc_s) / (double)ticks) * t_freq);
 }
 
 


### PR DESCRIPTION
tsc => hz calculation does
  measure_start (tsc_s)
  measure_end (first calculation)
  warmup
  measure_end (second calculation, tsc_e)

Calculation of hz was previously written as:
  (tsc_e - tsc_s) * t_freq / ticks
  where t_freq=1e9.
64 bit max is ~ 1.84e19 so if elapsed ticks is > 1.84e10, calculation
wrapped.  At 4GHz, this is 4.6s and a long warmup time would result
in incorrect calculation. Fixed by rewriting calculation.

Example with long warmup previously
```
$ taskset -c 2 ./scripts/onload ~/git/cns-sfnettest/src/sfnt-pingpong --affinity '2;2' --warmupms 5000 --sizes 0 udp 192.168.100.100 2>&1 | grep -i tsc
# tsc_hz: 4292002138
# WARNING: tsc_hz changed to 876189314 on recheck
```
WARNING now not shown,

### Tests to confirm tsc_hz result is same.

5 samples previous to change

```
pemberso@localhost$ taskset -c 2 ./scripts/onload ~/git/cns-sfnettest/src/sfnt-pingpong --affinity '2;2' --sizes 0 udp 192.168.100.100 2>&1 | grep -i tsc
# tsc_hz: 4292005990

pemberso@localhost$ taskset -c 2 ./scripts/onload ~/git/cns-sfnettest/src/sfnt-pingpong --affinity '2;2' --sizes 0 udp 192.168.100.100 2>&1 | grep -i tsc
# tsc_hz: 4292005585

pemberso@localhost$ taskset -c 2 ./scripts/onload ~/git/cns-sfnettest/src/sfnt-pingpong --affinity '2;2' --sizes 0 udp 192.168.100.100 2>&1 | grep -i tsc
# tsc_hz: 4292002027

pemberso@localhost$ taskset -c 2 ./scripts/onload ~/git/cns-sfnettest/src/sfnt-pingpong --affinity '2;2' --sizes 0 udp 192.168.100.100 2>&1 | grep -i tsc
# tsc_hz: 4292002090

pemberso@localhost$ taskset -c 2 ./scripts/onload ~/git/cns-sfnettest/src/sfnt-pingpong --affinity '2;2' --sizes 0 udp 192.168.100.100 2>&1 | grep -i tsc
# tsc_hz: 4291998116
```

5 samples taken after patch

```
pemberso@localhost$ taskset -c 2 ./scripts/onload ~/git/cns-sfnettest/src/sfnt-pingpong --affinity '2;2' --sizes 0 udp 192.168.100.100 2>&1 | grep -i tsc
# tsc_hz: 4292001997

pemberso@localhost$ taskset -c 2 ./scripts/onload ~/git/cns-sfnettest/src/sfnt-pingpong --affinity '2;2' --sizes 0 udp 192.168.100.100 2>&1 | grep -i tsc
# tsc_hz: 4292001977

pemberso@localhost$ taskset -c 2 ./scripts/onload ~/git/cns-sfnettest/src/sfnt-pingpong --affinity '2;2' --sizes 0 udp 192.168.100.100 2>&1 | grep -i tsc
# tsc_hz: 4291998251

pemberso@localhost$ taskset -c 2 ./scripts/onload ~/git/cns-sfnettest/src/sfnt-pingpong --affinity '2;2' --sizes 0 udp 192.168.100.100 2>&1 | grep -i tsc
# tsc_hz: 4292005551

pemberso@localhost$ taskset -c 2 ./scripts/onload ~/git/cns-sfnettest/src/sfnt-pingpong --affinity '2;2' --sizes 0 udp 192.168.100.100 2>&1 | grep -i tsc
# tsc_hz: 4292001764
```
