### PR TITLE
ON-17291: Report whether output is RTT or 1/2 RTT in run header

### DIFF
--- a/src/sfnt-pingpong.c
+++ b/src/sfnt-pingpong.c
@@ -1419,6 +1419,7 @@ static int do_client2(int ss, const char* hostport, int local)
   if( server_ld_preload != NULL )
     printf("# server LD_PRELOAD=%s\n", server_ld_preload);
   printf("# percentile=%g\n", (double) cfg_percentile);
+  printf("# reporting: %s\n", cfg_rtt ? "RTT" : "1/2 RTT");
   printf("#\n");
   printf("#\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
               "size", "mean", "min", "median", "max", "%ile", "stddev", "iter");

--- a/src/sfnt-stream.c
+++ b/src/sfnt-stream.c
@@ -1784,6 +1784,7 @@ static int do_client3(struct client_tx* ctx)
   if( ctx->server_ld_preload != NULL )
     printf("# server LD_PRELOAD=%s\n", ctx->server_ld_preload);
   printf("# percentile=%g\n", (double) cfg_percentile);
+  printf("# reporting: %s\n", cfg_rtt ? "RTT" : "1/2 RTT");
   printf("# msgsize=%zu\n", cfg_msg_size);
   fflush(stdout);
 


### PR DESCRIPTION
When running latency benchmarks, sfnt-pingpong and sfnt-stream can report results as full round-trip time (RTT) or as half-RTT (one-way latency estimate), depending on the --rtt option. Currently, the output header does not indicate which mode is active, making it ambiguous when reviewing saved results or comparing outputs from different runs. This is particularly relevant for helping customers convey performance evaluations and their consequent inquiries about results. Moreover, it is often easy to get confused when dealing with high figures (mid one-digit micros) about whether the results are RTTs or 1/2 RTTs. Also note that eflatency clearly states the type of result. 

```
eflatency:

# RX event type: EF_EVENT_TYPE_RX
paylen  mean    min     50%     95%     99%     max
0       11.635  11.307  11.609  11.638  12.119  25.365
mean round-trip time: 11.635 usec
```

This enhancement adds a # reporting: RTT or # reporting: 1/2 RTT line to the run header in both tools, making the output self-describing and reducing the risk of misinterpreting latency figures.

Now it runs as follows for full-RTT report:
```
andresa@sup-cap1:~/git/cns-sfnettest/src$ ./sfnt-pingpong --rtt udp 192.168.2.2
# cmdline: ./sfnt-pingpong --rtt udp 192.168.2.2
# version: b023367-modified
# src: 6e44b9b2572c75d1b25ed1981692f7b3
# date: Thu Mar 19 18:24:51 GMT 2026
# uname: Linux sup-cap1.xcblab.xilinx.com 4.18.0-553.el8_10.x86_64 #1 SMP Fri May 10 15:19:13 EDT 2024 x86_64 x86_64 x86_64 GNU/Linux
# cpu: model name       : Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz
...
# virbr0: driver: bridge
# virbr0: version: 2.3
# virbr0: bus-info: N/A
# ram: MemTotal:       263496216 kB
# tsc_hz: 2499985748
# percentile=99
# reporting: RTT
#
#       size    mean    min     median  max     %ile    stddev  iter
        0       24845   24066   24743   54831   27012   706     121000
        1       25088   24207   25000   56782   27028   707     119000
```

And for the half-RTT (default) report:
```
andresa@sup-cap1:~/git/cns-sfnettest/src$ ./sfnt-pingpong udp 192.168.2.2
# cmdline: ./sfnt-pingpong udp 192.168.2.2
# version: b023367-modified
# src: 6e44b9b2572c75d1b25ed1981692f7b3
# date: Thu Mar 19 18:25:14 GMT 2026
# uname: Linux sup-cap1.xcblab.xilinx.com 4.18.0-553.el8_10.x86_64 #1 SMP Fri May 10 15:19:13 EDT 2024 x86_64 x86_64 x86_64 GNU/Linux
# cpu: model name       : Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz
# lspci: 01:00.0 Ethernet controller: Broadcom Inc. and subsidiaries NetXtreme BCM5720 Gigabit Ethernet PCIe
# lspci: 01:00.1 Ethernet controller: Broadcom Inc. and subsidiaries NetXtreme BCM5720 Gigabit Ethernet PCIe
# lspci: 02:00.0 Ethernet controller: Broadcom Inc. and subsidiaries NetXtreme BCM5720 Gigabit Ethernet PCIe
# lspci: 02:00.1 Ethernet controller: Broadcom Inc. and subsidiaries NetXtreme BCM5720 Gigabit Ethernet PCIe
# lspci: 04:00.0 Ethernet controller: Solarflare Communications SFC9220 10/40G Ethernet Controller (rev 02)
# lspci: 04:00.1 Ethernet controller: Solarflare Communications SFC9220 10/40G Ethernet Controller (rev 02)
# lspci: 81:00.0 Ethernet controller: Solarflare Communications XtremeScale SFC9250 10/25/40/50/100G Ethernet Controller (rev ...
# ram: MemTotal:       263496216 kB
# tsc_hz: 2499994483
# percentile=99
# reporting: 1/2 RTT
#
#       size    mean    min     median  max     %ile    stddev  iter
        0       12982   12568   12909   27618   14197   438     115000
^C
```