### PR TITLE
ON-6825: sfnt-stream: Purge dead server.n_clients field.

### DIFF
--- a/src/sfnt-stream.c
+++ b/src/sfnt-stream.c
@@ -223,9 +223,8 @@ struct server {
   int       ss;
   int       read_fd;
   int       write_fd;
-  int       n_clients;
-  struct server_per_client clients[1];
   int       recv_size;
+  struct server_per_client client;
 };
 
 
@@ -855,7 +854,8 @@ static int do_server2(int ss)
   struct server server;
   struct sockaddr_storage sa;
   socklen_t sal = sizeof(sa);
-  int rc, i, sock;
+  char* hostport;
+  int rc, sock;
   int af;
 
   if( cfg_ipv4 )
@@ -924,22 +924,18 @@ static int do_server2(int ss)
   server.ss = ss;
   server.read_fd = sock;
   server.write_fd = sock;
-  server.n_clients = 1;
   server.recv_size = sizeof(ppbuf);
   /* TODO: for streaming fd_types we need to set recv_size to the size of
      the message */
 
-  for( i = 0; i < server.n_clients; ++i ) {
-    char* hostport;
-    client = &server.clients[i];
-    memset(client, 0, sizeof(*client));
-    hostport = sfnt_sock_get_str(ss);
-    if( ! sfnt_quiet )
-      sfnt_err("sfnt-stream: server: client %d at %s\n", i, hostport);
-    NT_TRY_GAI(sfnt_getaddrinfo(AF_UNSPEC, hostport, NULL,
-                                -1, &client->addrinfo));
-    free(hostport);
-  }
+  client = &server.client;
+  memset(client, 0, sizeof(*client));
+  hostport = sfnt_sock_get_str(ss);
+  if( ! sfnt_quiet )
+    sfnt_err("sfnt-stream: server: client at %s\n", hostport);
+  NT_TRY_GAI(sfnt_getaddrinfo(AF_UNSPEC, hostport, NULL,
+                              -1, &client->addrinfo));
+  free(hostport);
 
   return do_server3(&server);
 }
@@ -988,7 +984,7 @@ static int do_server3(struct server* server)
 
     if( rc > 0 ) {
       uint32_t seq = NT_LE32(msg->seq);
-      client = &server->clients[0];
+      client = &server->client;
       if( ! (msg->flags & MF_RESET) ) {
         if( seq == client->seq_expected ) {
           ++client->seq_expected;


### PR DESCRIPTION
Apply this cleanup from the `extension` branch to `master`, where it is also applicable, reducing delta between branches.

When applied, this eliminates a false positive from`gcc -fanalyzer -Wanalyzer-out-of-bounds`.


(cherry picked from commit da4bef000826a63699869be1df88cdd075bb19cc)