### PR TITLE
ON-17312: el7: revert "C99 -Wall: fix -Wimplicit-function-declaration"

### DIFF
--- a/src/sfnettest.h
+++ b/src/sfnettest.h
@@ -12,20 +12,11 @@
 #ifndef __SFNETTEST_H__
 #define __SFNETTEST_H__
 
-/* Access POSIX clock_*() and getaddrinfo() families and kill(), behind
- * glibc feature test macros. */
-#define _XOPEN_SOURCE 700
-
-/* Access usleep(3) through glibc feature test macros before unist.h
- * gets indirectly included. */
-#define _DEFAULT_SOURCE
-
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 #include <stdint.h>
 #include <assert.h>
 #include <math.h>


### PR DESCRIPTION
This reverts commit d0a51b42766bd8030cb97b7380adda913bf0a050.

The feature test macros caused trouble with EL7 builds but are only needed if you tie the compiler to a C standard, which is not critical, so let's drop for now.
.
Tested with CentOS7/gcc-4.8.5 and Debian14/gcc-16