### PR TITLE
ON-17328: fix tcpdirect build regressions

### DIFF
--- a/src/sfnt-pingpong.c
+++ b/src/sfnt-pingpong.c
@@ -2687,8 +2687,6 @@ static int do_client2(int ss, const char* hostport, int local)
     NT_TRY(zf_tcp_connect(ss, th, host, port, &read_h.t));
     write_h.t = read_h.t;
     break;
-  default:
-    NT_ASSERT(0);
   }
 #endif
 #ifdef USE_DPDK

--- a/src/sfnt-stream.c
+++ b/src/sfnt-stream.c
@@ -1322,7 +1322,7 @@ static int do_server2(int ss)
   if( handle_type == HT_ZF_UDP )
     NT_TRY(zfut_alloc(&server.write_handle.ut, ztack,
                       (struct sockaddr*) &my_sa, sizeof(my_sa),
-                      to_sa, to_sa_len, 0, zattr));
+                      (struct sockaddr*) &to_sa, to_sa_len, 0, zattr));
 #endif
 
   return do_server3(&server);
@@ -2239,7 +2239,7 @@ static int do_client2(int ss, const char* hostport, int local)
   case HT_ZF_UDP: {
     char reply_hostport[80];
 
-    NT_TESTi3(sa.ss_family, ==, AF_INET);
+    NT_TESTi3(to_sa.ss_family, ==, AF_INET);
     NT_TRY(zfut_alloc(&ctx->write_handle.ut, ztack_client_tx,
                       (struct sockaddr*) &my_sa, sizeof(struct sockaddr_in),
                       ai->ai_addr, ai->ai_addrlen, 0, zattr));


### PR DESCRIPTION
Fixes these errors arising from the recent merge to the extension branch.

```
cc -Wall -Werror -g -DSFNT_VERSION='"fef4cf7-modified"' -DSFNT_SRC_CSUM='"316275ccc828066fa3d1c425855a0e57"' -DUSE_ZF -I../../onload/src/include -I../../tcpdirect/src/include   -c -o sfnt-pingpong.o sfnt-pingpong.c
sfnt-pingpong.c: In function ‘do_client2’:
sfnt-pingpong.c:2690:3: error: switch jumps into scope of identifier with variably modified type
 2690 |   default:
      |   ^~~~~~~
sfnt-pingpong.c:2631:3: note: switch starts here
 2631 |   switch( handle_type ) {
      |   ^~~~~~
sfnt-pingpong.c:2678:10: note: ‘host’ declared here
 2678 |     char host[strlen(hostport) + 1];
      |          ^~~~
make: *** [<builtin>: sfnt-pingpong.o] Error 1
cc -Wall -Werror -g -DSFNT_VERSION='"fef4cf7-modified"' -DSFNT_SRC_CSUM='"316275ccc828066fa3d1c425855a0e57"' -DUSE_ZF -I../../onload/src/include -I../../tcpdirect/src/include  -c -o sfnt-stream.o sfnt-stream.c
In file included from sfnt-stream.c:13:
sfnt-stream.c: In function ‘do_server2’:
sfnt-stream.c:1325:23: error: incompatible type for argument 5 of ‘zfut_alloc’
 1325 |                       to_sa, to_sa_len, 0, zattr));
      |                       ^~~~~
      |                       |
      |                       struct sockaddr_storage
sfnettest.h:178:18: note: in definition of macro ‘NT_TRY’
  178 |   if( ((__rc) = (x)) < 0 ) {                                    \
      |                  ^
In file included from ../../tcpdirect/src/include/zf/zf.h:22,
                 from sfnt-stream.c:17:
../../tcpdirect/src/include/zf/zf_udp.h:316:35: note: expected ‘const struct sockaddr *’ but argument is of type ‘struct sockaddr_storage’
  316 |            const struct sockaddr* raddr,
      |            ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
sfnt-stream.c: In function ‘do_client2’:
sfnt-stream.c:2242:15: error: ‘sa’ undeclared (first use in this function); did you mean ‘ss’?
 2242 |     NT_TESTi3(sa.ss_family, ==, AF_INET);
      |               ^~
sfnettest.h:157:14: note: in definition of macro ‘__NT_TESTi3’
  157 |   int __a = (a);                                                        \
      |              ^
sfnt-stream.c:2242:5: note: in expansion of macro ‘NT_TESTi3’
 2242 |     NT_TESTi3(sa.ss_family, ==, AF_INET);
      |     ^~~~~~~~~
sfnt-stream.c:2242:15: note: each undeclared identifier is reported only once for each function it appears in
 2242 |     NT_TESTi3(sa.ss_family, ==, AF_INET);
      |               ^~
sfnettest.h:157:14: note: in definition of macro ‘__NT_TESTi3’
  157 |   int __a = (a);                                                        \
      |              ^
sfnt-stream.c:2242:5: note: in expansion of macro ‘NT_TESTi3’
 2242 |     NT_TESTi3(sa.ss_family, ==, AF_INET);
      |     ^~~~~~~~~
make: *** [<builtin>: sfnt-stream.o] Error 1
make: Target 'default' not remade because of errors.
make: Leaving directory '/home/abower/git/cns-sfnettest/src'
```